### PR TITLE
Use correct path for aars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ deploy:
   provider: releases
   api_key: "${GITHUB_API_KEY}"
   file_glob: true
-  file: ./*/build/libs/*.aar
+  file: ./*/build/outputs/aar/*.aar
   skip_cleanup: true
   on:
     tags: true


### PR DESCRIPTION
Changes proposed in this pull request:
- Use correct path for aar files to upload
- Will upload a `-release` and a `-debug` version of the libraries

@gnosis/mobile-devs
