### PR TITLE
Added block parameter

### DIFF
--- a/accounts-kethereum/src/test/java/pm/gnosis/svalinn/accounts/repositories/impls/KethereumAccountsRepositoryTest.kt
+++ b/accounts-kethereum/src/test/java/pm/gnosis/svalinn/accounts/repositories/impls/KethereumAccountsRepositoryTest.kt
@@ -16,7 +16,6 @@ import pm.gnosis.models.Wei
 import pm.gnosis.svalinn.accounts.base.models.Signature
 import pm.gnosis.svalinn.accounts.data.db.AccountDao
 import pm.gnosis.svalinn.accounts.data.db.AccountsDatabase
-import pm.gnosis.svalinn.accounts.repositories.impls.KethereumAccountsRepository
 import pm.gnosis.svalinn.accounts.repositories.impls.models.db.AccountDb
 import pm.gnosis.svalinn.accounts.utils.rlp
 import pm.gnosis.svalinn.common.PreferencesManager

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -1,7 +1,7 @@
 ext {
     versions = [
             // Plug-Ins
-            android_tools          : '3.1.0-rc01',
+            android_tools          : '3.1.0-rc02',
             fabric                 : '1.+',
             google_services        : '3.1.0',
             kotlin                 : '1.2.21',

--- a/ethereum-rpc/src/main/java/pm/gnosis/ethereum/rpc/models/RpcRequests.kt
+++ b/ethereum-rpc/src/main/java/pm/gnosis/ethereum/rpc/models/RpcRequests.kt
@@ -1,6 +1,7 @@
 package pm.gnosis.ethereum.rpc.models
 
 import pm.gnosis.ethereum.*
+import pm.gnosis.ethereum.rpc.EthereumRpcConnector
 import pm.gnosis.ethereum.rpc.EthereumRpcConnector.Companion.BLOCK_LATEST
 import pm.gnosis.ethereum.rpc.EthereumRpcConnector.Companion.BLOCK_PENDING
 import pm.gnosis.ethereum.rpc.EthereumRpcConnector.Companion.FUNCTION_CALL
@@ -28,7 +29,7 @@ class RpcCallRequest(raw: EthCall) : RpcRequest<EthCall>(raw) {
             method = FUNCTION_CALL,
             params = listOf(
                 raw.transaction.toCallParams(raw.from?.asEthereumAddressStringOrNull()),
-                BLOCK_LATEST
+                raw.block.asString()
             ),
             id = raw.id
         )
@@ -44,7 +45,7 @@ class RpcBalanceRequest(raw: EthBalance) : RpcRequest<EthBalance>(raw) {
     override fun request() =
         JsonRpcRequest(
             method = FUNCTION_GET_BALANCE,
-            params = listOf(raw.address.asEthereumAddressString(), BLOCK_LATEST),
+            params = listOf(raw.address.asEthereumAddressString(), raw.block.asString()),
             id = raw.id
         )
 
@@ -96,7 +97,7 @@ class RpcTransactionCountRequest(raw: EthGetTransactionCount) :
     override fun request() =
         JsonRpcRequest(
             method = FUNCTION_GET_TRANSACTION_COUNT,
-            params = arrayListOf(raw.from.asEthereumAddressString(), BLOCK_PENDING),
+            params = arrayListOf(raw.from.asEthereumAddressString(), raw.block.asString()),
             id = raw.id
         )
 
@@ -134,3 +135,11 @@ private fun Transaction?.toCallParams(from: String?) =
         gas = this?.gas?.toHexString(),
         gasPrice = this?.gasPrice?.toHexString()
     )
+
+private fun Block.asString() =
+    when(this) {
+        is BlockNumber -> number.toHexString()
+        is BlockEarliest -> EthereumRpcConnector.BLOCK_EARLIEST
+        is BlockLatest -> EthereumRpcConnector.BLOCK_LATEST
+        is BlockPending -> EthereumRpcConnector.BLOCK_PENDING
+    }

--- a/ethereum-rpc/src/test/java/pm/gnosis/ethereum/rpc/models/RpcRequestTest.kt
+++ b/ethereum-rpc/src/test/java/pm/gnosis/ethereum/rpc/models/RpcRequestTest.kt
@@ -67,7 +67,45 @@ class RpcRequestTest {
             TestCase(
                 RpcCallRequest(EthCall(BigInteger.ONE, TEST_TX, id = 10)),
                 "eth_call",
+                listOf(TEST_CALL_PARAMS, "pending"),
+                rpcResult("0x01", id = 10),
+                EthRequest.Response.Success("0x01"),
+                10
+            ),
+            TestCase(
+                RpcCallRequest(EthCall(BigInteger.ONE, TEST_TX, id = 10, block = Block.PENDING)),
+                "eth_call",
+                listOf(TEST_CALL_PARAMS, "pending"),
+                rpcResult("0x01", id = 10),
+                EthRequest.Response.Success("0x01"),
+                10
+            ),
+            TestCase(
+                RpcCallRequest(EthCall(BigInteger.ONE, TEST_TX, id = 10, block = Block.LATEST)),
+                "eth_call",
                 listOf(TEST_CALL_PARAMS, "latest"),
+                rpcResult("0x01", id = 10),
+                EthRequest.Response.Success("0x01"),
+                10
+            ),
+            TestCase(
+                RpcCallRequest(EthCall(BigInteger.ONE, TEST_TX, id = 10, block = Block.EARLIEST)),
+                "eth_call",
+                listOf(TEST_CALL_PARAMS, "earliest"),
+                rpcResult("0x01", id = 10),
+                EthRequest.Response.Success("0x01"),
+                10
+            ),
+            TestCase(
+                RpcCallRequest(
+                    EthCall(
+                        BigInteger.ONE, TEST_TX, id = 10, block = BlockNumber(
+                            BigInteger.TEN
+                        )
+                    )
+                ),
+                "eth_call",
+                listOf(TEST_CALL_PARAMS, "0xa"),
                 rpcResult("0x01", id = 10),
                 EthRequest.Response.Success("0x01"),
                 10
@@ -75,7 +113,7 @@ class RpcRequestTest {
             TestCase(
                 RpcCallRequest(EthCall(BigInteger.ONE, TEST_TX)),
                 "eth_call",
-                listOf(TEST_CALL_PARAMS, "latest"),
+                listOf(TEST_CALL_PARAMS, "pending"),
                 rpcResult(error = "Some Error"),
                 EthRequest.Response.Failure<String>("Some Error")
             ),
@@ -84,7 +122,45 @@ class RpcRequestTest {
             TestCase(
                 RpcBalanceRequest(EthBalance(BigInteger.ONE, id = 1)),
                 "eth_getBalance",
+                listOf(BigInteger.ONE.asEthereumAddressString(), "pending"),
+                rpcResult(Wei.ether("1").value.toHexString(), id = 1),
+                EthRequest.Response.Success(Wei.ether("1")),
+                1
+            ),
+            TestCase(
+                RpcBalanceRequest(EthBalance(BigInteger.ONE, id = 1, block = Block.PENDING)),
+                "eth_getBalance",
+                listOf(BigInteger.ONE.asEthereumAddressString(), "pending"),
+                rpcResult(Wei.ether("1").value.toHexString(), id = 1),
+                EthRequest.Response.Success(Wei.ether("1")),
+                1
+            ),
+            TestCase(
+                RpcBalanceRequest(EthBalance(BigInteger.ONE, id = 1, block = Block.LATEST)),
+                "eth_getBalance",
                 listOf(BigInteger.ONE.asEthereumAddressString(), "latest"),
+                rpcResult(Wei.ether("1").value.toHexString(), id = 1),
+                EthRequest.Response.Success(Wei.ether("1")),
+                1
+            ),
+            TestCase(
+                RpcBalanceRequest(EthBalance(BigInteger.ONE, id = 1, block = Block.EARLIEST)),
+                "eth_getBalance",
+                listOf(BigInteger.ONE.asEthereumAddressString(), "earliest"),
+                rpcResult(Wei.ether("1").value.toHexString(), id = 1),
+                EthRequest.Response.Success(Wei.ether("1")),
+                1
+            ),
+            TestCase(
+                RpcBalanceRequest(
+                    EthBalance(
+                        BigInteger.ONE,
+                        id = 1,
+                        block = BlockNumber(BigInteger.ONE)
+                    )
+                ),
+                "eth_getBalance",
+                listOf(BigInteger.ONE.asEthereumAddressString(), "0x1"),
                 rpcResult(Wei.ether("1").value.toHexString(), id = 1),
                 EthRequest.Response.Success(Wei.ether("1")),
                 1
@@ -92,14 +168,14 @@ class RpcRequestTest {
             TestCase(
                 RpcBalanceRequest(EthBalance(BigInteger.ONE)),
                 "eth_getBalance",
-                listOf(BigInteger.ONE.asEthereumAddressString(), "latest"),
+                listOf(BigInteger.ONE.asEthereumAddressString(), "pending"),
                 rpcResult(error = "Some Error"),
                 EthRequest.Response.Failure<Wei>("Some Error")
             ),
             TestCase(
                 RpcBalanceRequest(EthBalance(BigInteger.ONE)),
                 "eth_getBalance",
-                listOf(BigInteger.ONE.asEthereumAddressString(), "latest"),
+                listOf(BigInteger.ONE.asEthereumAddressString(), "pending"),
                 rpcResult("Invalid Number"),
                 EthRequest.Response.Failure<Wei>("Invalid balance!")
             ),
@@ -157,6 +233,62 @@ class RpcRequestTest {
                 RpcTransactionCountRequest(EthGetTransactionCount(BigInteger.TEN, id = 12)),
                 "eth_getTransactionCount",
                 listOf(BigInteger.TEN.asEthereumAddressString(), "pending"),
+                rpcResult(BigInteger.valueOf(23).toHexString()),
+                EthRequest.Response.Success(BigInteger.valueOf(23)),
+                12
+            ),
+            TestCase(
+                RpcTransactionCountRequest(
+                    EthGetTransactionCount(
+                        BigInteger.TEN,
+                        id = 12,
+                        block = Block.PENDING
+                    )
+                ),
+                "eth_getTransactionCount",
+                listOf(BigInteger.TEN.asEthereumAddressString(), "pending"),
+                rpcResult(BigInteger.valueOf(23).toHexString()),
+                EthRequest.Response.Success(BigInteger.valueOf(23)),
+                12
+            ),
+            TestCase(
+                RpcTransactionCountRequest(
+                    EthGetTransactionCount(
+                        BigInteger.TEN,
+                        id = 12,
+                        block = Block.LATEST
+                    )
+                ),
+                "eth_getTransactionCount",
+                listOf(BigInteger.TEN.asEthereumAddressString(), "latest"),
+                rpcResult(BigInteger.valueOf(23).toHexString()),
+                EthRequest.Response.Success(BigInteger.valueOf(23)),
+                12
+            ),
+            TestCase(
+                RpcTransactionCountRequest(
+                    EthGetTransactionCount(
+                        BigInteger.TEN,
+                        id = 12,
+                        block = Block.EARLIEST
+                    )
+                ),
+                "eth_getTransactionCount",
+                listOf(BigInteger.TEN.asEthereumAddressString(), "earliest"),
+                rpcResult(BigInteger.valueOf(23).toHexString()),
+                EthRequest.Response.Success(BigInteger.valueOf(23)),
+                12
+            ),
+            TestCase(
+                RpcTransactionCountRequest(
+                    EthGetTransactionCount(
+                        BigInteger.TEN, id = 12, block = BlockNumber(
+                            BigInteger.ZERO
+                        )
+                    )
+                ),
+                "eth_getTransactionCount",
+                listOf(BigInteger.TEN.asEthereumAddressString(), "0x0"),
                 rpcResult(BigInteger.valueOf(23).toHexString()),
                 EthRequest.Response.Success(BigInteger.valueOf(23)),
                 12

--- a/ethereum/src/main/java/pm/gnosis/ethereum/EthereumRepository.kt
+++ b/ethereum/src/main/java/pm/gnosis/ethereum/EthereumRepository.kt
@@ -57,11 +57,11 @@ sealed class EthRequest<T>(val id: Int) {
     @Throws(RequestFailedException::class, RequestNotExecutedException::class)
     fun checkedResult(errorMsg: String? = null): T =
         response.let {
-            when(it) {
+            when (it) {
                 is EthRequest.Response.Success ->
                     it.data
                 is EthRequest.Response.Failure -> {
-                    val msg = it.error + (errorMsg?.let {" ($it)"} ?: "")
+                    val msg = it.error + (errorMsg?.let { " ($it)" } ?: "")
                     throw RequestFailedException(msg)
                 }
                 null ->
@@ -78,10 +78,12 @@ sealed class EthRequest<T>(val id: Int) {
 class EthCall(
     val from: BigInteger? = null,
     val transaction: Transaction? = null,
-    id: Int = 0
+    id: Int = 0,
+    val block: Block = Block.PENDING
 ) : EthRequest<String>(id)
 
-class EthBalance(val address: BigInteger, id: Int = 0) : EthRequest<Wei>(id)
+class EthBalance(val address: BigInteger, id: Int = 0, val block: Block = Block.PENDING) :
+    EthRequest<Wei>(id)
 
 class EthGasPrice(id: Int = 0) : EthRequest<BigInteger>(id)
 
@@ -91,12 +93,29 @@ class EthEstimateGas(
     id: Int = 0
 ) : EthRequest<BigInteger>(id)
 
-class EthGetTransactionCount(val from: BigInteger, id: Int = 0) : EthRequest<BigInteger>(id)
+class EthGetTransactionCount(val from: BigInteger, id: Int = 0, val block: Block = Block.PENDING) :
+    EthRequest<BigInteger>(id)
 
 class EthSendRawTransaction(val signedData: String, id: Int = 0) : EthRequest<String>(id)
 
 class TransactionReceiptNotFound : NoSuchElementException()
 
-class RequestFailedException(msg: String? = null): RuntimeException(msg)
+class RequestFailedException(msg: String? = null) : RuntimeException(msg)
 
-class RequestNotExecutedException(msg: String? = null): RuntimeException(msg)
+class RequestNotExecutedException(msg: String? = null) : RuntimeException(msg)
+
+sealed class Block {
+    companion object {
+        val PENDING = BlockPending()
+        val LATEST = BlockLatest()
+        val EARLIEST = BlockEarliest()
+    }
+}
+
+class BlockNumber(val number: BigInteger) : Block()
+
+class BlockEarliest internal constructor(): Block()
+
+class BlockLatest internal constructor() : Block()
+
+class BlockPending internal constructor() : Block()


### PR DESCRIPTION
Changes proposed in this pull request:
Before we used `latest` as the default block parameter (except for getTransactionCount where we used `pending`). Now `pending` is the default block parameter for all calls and it is possible to specify the block (`pending`, `latest`, `earliest` or a block number).

@gnosis/mobile-devs
