### PR TITLE
Recover Signature from Transactions which use Chain ID. Closes #17

### DIFF
--- a/accounts-base/src/main/java/pm/gnosis/svalinn/accounts/base/models/Signature.kt
+++ b/accounts-base/src/main/java/pm/gnosis/svalinn/accounts/base/models/Signature.kt
@@ -4,6 +4,10 @@ import java.math.BigInteger
 
 
 data class Signature(val r: BigInteger, val s: BigInteger, val v: Byte) {
+    init {
+        if (v !in 27..34) throw IllegalStateException("v not in valid range")
+    }
+
     override fun toString(): String {
         return r.toString(16).padStart(64, '0').substring(0, 64) +
                 s.toString(16).padStart(64, '0').substring(0, 64) +
@@ -11,12 +15,20 @@ data class Signature(val r: BigInteger, val s: BigInteger, val v: Byte) {
     }
 
     companion object {
-        fun from(encoded: String): Signature {
+        fun from(encoded: String, chainId: Int = 0): Signature {
             if (encoded.length != 130) throw IllegalArgumentException()
             val r = BigInteger(encoded.substring(0, 64), 16)
             val s = BigInteger(encoded.substring(64, 128), 16)
-            val v = encoded.substring(128, 130).toByte(16)
+            val v = encoded.substring(128, 130).toByte(16).adjustV(chainId)
+
             return Signature(r, s, v)
         }
+
+        fun fromChainId(r: BigInteger, s: BigInteger, v: Byte, chainId: Int) = Signature(r, s, v.adjustV(chainId))
+
+        private fun Byte.adjustV(chainId: Int) = this.toInt().let {
+            if (it >= 35) it - 8 - 2 * chainId
+            else it
+        }.toByte()
     }
 }

--- a/accounts-base/src/main/java/pm/gnosis/svalinn/accounts/base/models/Signature.kt
+++ b/accounts-base/src/main/java/pm/gnosis/svalinn/accounts/base/models/Signature.kt
@@ -19,9 +19,9 @@ data class Signature(val r: BigInteger, val s: BigInteger, val v: Byte) {
             if (encoded.length != 130) throw IllegalArgumentException()
             val r = BigInteger(encoded.substring(0, 64), 16)
             val s = BigInteger(encoded.substring(64, 128), 16)
-            val v = encoded.substring(128, 130).toByte(16).adjustV(chainId)
+            val v = encoded.substring(128, 130).toByte(16)
 
-            return Signature(r, s, v)
+            return Signature.fromChainId(r, s, v, chainId)
         }
 
         fun fromChainId(r: BigInteger, s: BigInteger, v: Byte, chainId: Int) = Signature(r, s, v.adjustV(chainId))

--- a/accounts-base/src/test/java/pm/gnosis/svalinn/accounts/base/models/SignatureTest.kt
+++ b/accounts-base/src/test/java/pm/gnosis/svalinn/accounts/base/models/SignatureTest.kt
@@ -1,6 +1,7 @@
 package pm.gnosis.svalinn.accounts.base.models
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
 import org.junit.Test
 import java.math.BigInteger
 
@@ -17,5 +18,31 @@ class SignatureTest {
             encoded
         )
         assertEquals(sig, Signature.from(encoded))
+    }
+
+    @Test
+    fun testInvalidV() {
+        try {
+            val r = BigInteger("6c65af8fabdf55b026300ccb4cf1c19f27592a81c78aba86abe83409563d9c13", 16)
+            val s = BigInteger("256a9a9e87604e89f083983f7449f58a456ac7929265f7114d585538fe226e1f", 16)
+            val v = 35.toByte()
+            Signature(r, s, v)
+            fail()
+        } catch (exception: IllegalStateException) {
+        }
+
+        try {
+            val r = BigInteger("6c65af8fabdf55b026300ccb4cf1c19f27592a81c78aba86abe83409563d9c13", 16)
+            val s = BigInteger("256a9a9e87604e89f083983f7449f58a456ac7929265f7114d585538fe226e1f", 16)
+            val v = 26.toByte()
+            Signature(r, s, v)
+            fail()
+        } catch (exception: IllegalStateException) {
+        }
+
+        val r = BigInteger("6c65af8fabdf55b026300ccb4cf1c19f27592a81c78aba86abe83409563d9c13", 16)
+        val s = BigInteger("256a9a9e87604e89f083983f7449f58a456ac7929265f7114d585538fe226e1f", 16)
+        val v = 27.toByte()
+        Signature(r, s, v)
     }
 }

--- a/accounts-base/src/test/java/pm/gnosis/svalinn/accounts/base/models/SignatureTest.kt
+++ b/accounts-base/src/test/java/pm/gnosis/svalinn/accounts/base/models/SignatureTest.kt
@@ -22,9 +22,10 @@ class SignatureTest {
 
     @Test
     fun testInvalidV() {
+        val r = BigInteger("6c65af8fabdf55b026300ccb4cf1c19f27592a81c78aba86abe83409563d9c13", 16)
+        val s = BigInteger("256a9a9e87604e89f083983f7449f58a456ac7929265f7114d585538fe226e1f", 16)
+
         try {
-            val r = BigInteger("6c65af8fabdf55b026300ccb4cf1c19f27592a81c78aba86abe83409563d9c13", 16)
-            val s = BigInteger("256a9a9e87604e89f083983f7449f58a456ac7929265f7114d585538fe226e1f", 16)
             val v = 35.toByte()
             Signature(r, s, v)
             fail()
@@ -32,16 +33,12 @@ class SignatureTest {
         }
 
         try {
-            val r = BigInteger("6c65af8fabdf55b026300ccb4cf1c19f27592a81c78aba86abe83409563d9c13", 16)
-            val s = BigInteger("256a9a9e87604e89f083983f7449f58a456ac7929265f7114d585538fe226e1f", 16)
             val v = 26.toByte()
             Signature(r, s, v)
             fail()
         } catch (exception: IllegalStateException) {
         }
 
-        val r = BigInteger("6c65af8fabdf55b026300ccb4cf1c19f27592a81c78aba86abe83409563d9c13", 16)
-        val s = BigInteger("256a9a9e87604e89f083983f7449f58a456ac7929265f7114d585538fe226e1f", 16)
         val v = 27.toByte()
         Signature(r, s, v)
     }

--- a/accounts-kethereum/src/test/java/pm/gnosis/svalinn/accounts/repositories/impls/KethereumAccountsRepositoryTest.kt
+++ b/accounts-kethereum/src/test/java/pm/gnosis/svalinn/accounts/repositories/impls/KethereumAccountsRepositoryTest.kt
@@ -154,6 +154,23 @@ class KethereumAccountsRepositoryTest {
         recoverObserver.assertResult("a5056c8efadb5d6a1a6eb0176615692b6e648313".asEthereumAddress())
     }
 
+    @Test
+    fun recoverEIP155() {
+        // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#example
+        val expectedData = "0xdaf5a779ae972f972197303d7b574746c7ef83eadac0f2791ad23db92e4c8e53".hexStringToByteArray()
+        val testObserver = TestObserver.create<Solidity.Address>()
+
+        repository.recover(
+            expectedData,
+            Signature.fromChainId(
+                "18515461264373351373200002665853028612451056578545711640558177340181847433846".toBigInteger(),
+                "46948507304638947509940763649030358759909902576025900602547168820602576006531".toBigInteger(),
+                37.toByte(), chainId = 1
+            )
+        ).subscribe(testObserver)
+        testObserver.assertResult("0x9d8a62f656a8d1615c1294fd71e9cfb3e4855a4f".asEthereumAddress())
+    }
+
     companion object {
 
         const val CREATE_SAFE_DATA = "0x" +


### PR DESCRIPTION
Closes #17 .

Changes proposed in this pull request:
- It is now possible to recover a signature from transactions that use the chain id ([EIP155](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#example)).

@gnosis/mobile-devs
