### PR TITLE
Fingerprint recoverable errors no longer complete the observable source

### DIFF
--- a/security/src/main/java/pm/gnosis/svalinn/security/impls/AndroidFingerprintHelper.kt
+++ b/security/src/main/java/pm/gnosis/svalinn/security/impls/AndroidFingerprintHelper.kt
@@ -114,7 +114,6 @@ class AndroidFingerprintHelper(private val context: Context) : FingerprintHelper
 
         override fun onAuthenticationHelp(helpMsgId: Int, helpString: CharSequence?) {
             emitter?.onNext(AuthenticationHelp(helpMsgId, helpString))
-            emitter?.onComplete()
         }
     }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Previously the fingerprint observable emitted a terminal event (`onComplete`) when a recoverable error occurred during authentication. Now it just emits the event.

@gnosis/mobile-devs
