### PR TITLE
Make Result optional

### DIFF
--- a/ethereum-rpc/src/main/java/pm/gnosis/ethereum/rpc/models/JsonRpcResult.kt
+++ b/ethereum-rpc/src/main/java/pm/gnosis/ethereum/rpc/models/JsonRpcResult.kt
@@ -18,7 +18,7 @@ data class JsonRpcResult(
     @Json(name = "id") val id: Int,
     @Json(name = "jsonrpc") val jsonRpc: String,
     @Json(name = "error") val error: JsonRpcError? = null,
-    @Json(name = "result") val result: String
+    @Json(name = "result") val result: String?
 )
 
 @JsonClass(generateAdapter = true)

--- a/ethereum-rpc/src/main/java/pm/gnosis/ethereum/rpc/models/RpcRequests.kt
+++ b/ethereum-rpc/src/main/java/pm/gnosis/ethereum/rpc/models/RpcRequests.kt
@@ -33,7 +33,8 @@ class RpcCallRequest(raw: EthCall) : RpcRequest<EthCall>(raw) {
 
     override fun parse(response: JsonRpcResult) {
         raw.response = response.error?.let { EthRequest.Response.Failure<String>(it.message) }
-                ?: EthRequest.Response.Success(response.result)
+                ?: response.result?.let { EthRequest.Response.Success(response.result) }
+                ?: EthRequest.Response.Failure("Missing result")
     }
 }
 
@@ -47,7 +48,8 @@ class RpcBalanceRequest(raw: EthBalance) : RpcRequest<EthBalance>(raw) {
 
     override fun parse(response: JsonRpcResult) {
         raw.response = response.error?.let { EthRequest.Response.Failure<Wei>(it.message) }
-                ?: response.result.hexAsBigIntegerOrNull()?.let { EthRequest.Response.Success(Wei(it)) }
+                ?:
+                response.result?.hexAsBigIntegerOrNull()?.let { EthRequest.Response.Success(Wei(it)) }
                 ?: EthRequest.Response.Failure("Invalid balance!")
     }
 }
@@ -64,7 +66,7 @@ class RpcEstimateGasRequest(raw: EthEstimateGas) : RpcRequest<EthEstimateGas>(ra
 
     override fun parse(response: JsonRpcResult) {
         raw.response = response.error?.let { EthRequest.Response.Failure<BigInteger>(it.message) }
-                ?: response.result.hexAsBigIntegerOrNull()?.let { EthRequest.Response.Success(it) }
+                ?: response.result?.hexAsBigIntegerOrNull()?.let { EthRequest.Response.Success(it) }
                 ?: EthRequest.Response.Failure("Invalid estimate!")
     }
 }
@@ -78,7 +80,7 @@ class RpcGasPriceRequest(raw: EthGasPrice) : RpcRequest<EthGasPrice>(raw) {
 
     override fun parse(response: JsonRpcResult) {
         raw.response = response.error?.let { EthRequest.Response.Failure<BigInteger>(it.message) }
-                ?: response.result.hexAsBigIntegerOrNull()?.let { EthRequest.Response.Success(it) }
+                ?: response.result?.hexAsBigIntegerOrNull()?.let { EthRequest.Response.Success(it) }
                 ?: EthRequest.Response.Failure("Invalid gas price!")
     }
 }
@@ -94,7 +96,7 @@ class RpcTransactionCountRequest(raw: EthGetTransactionCount) :
 
     override fun parse(response: JsonRpcResult) {
         raw.response = response.error?.let { EthRequest.Response.Failure<BigInteger>(it.message) }
-                ?: response.result.hexAsBigIntegerOrNull()?.let { EthRequest.Response.Success(it) }
+                ?: response.result?.hexAsBigIntegerOrNull()?.let { EthRequest.Response.Success(it) }
                 ?: EthRequest.Response.Failure("Invalid transaction count!")
     }
 }
@@ -110,7 +112,8 @@ class RpcSendRawTransaction(raw: EthSendRawTransaction) : RpcRequest<EthSendRawT
     override fun parse(response: JsonRpcResult) {
         raw.response =
                 response.error?.let { EthRequest.Response.Failure<String>(it.message) }
-                ?: EthRequest.Response.Success(response.result)
+                ?: response.result?.let { EthRequest.Response.Success(response.result) }
+                ?: EthRequest.Response.Failure("Missing result")
     }
 }
 

--- a/ethereum-rpc/src/test/java/pm/gnosis/ethereum/rpc/models/RpcRequestTest.kt
+++ b/ethereum-rpc/src/test/java/pm/gnosis/ethereum/rpc/models/RpcRequestTest.kt
@@ -117,6 +117,13 @@ class RpcRequestTest {
                 rpcResult(error = "Some Error"),
                 EthRequest.Response.Failure<String>("Some Error")
             ),
+            TestCase(
+                RpcCallRequest(EthCall(Solidity.Address(BigInteger.ONE), TEST_TX)),
+                "eth_call",
+                listOf(TEST_CALL_PARAMS, "pending"),
+                rpcResult(),
+                EthRequest.Response.Failure<String>("Missing result")
+            ),
 
             // GetBalance
             TestCase(
@@ -179,6 +186,13 @@ class RpcRequestTest {
                 rpcResult("Invalid Number"),
                 EthRequest.Response.Failure<Wei>("Invalid balance!")
             ),
+            TestCase(
+                RpcBalanceRequest(EthBalance(Solidity.Address(BigInteger.ONE))),
+                "eth_getBalance",
+                listOf(Solidity.Address(BigInteger.ONE).asEthereumAddressString(), "pending"),
+                rpcResult(),
+                EthRequest.Response.Failure<Wei>("Invalid balance!")
+            ),
 
             // EstimateGas
             TestCase(
@@ -203,6 +217,13 @@ class RpcRequestTest {
                 rpcResult("Invalid Number"),
                 EthRequest.Response.Failure<BigInteger>("Invalid estimate!")
             ),
+            TestCase(
+                RpcEstimateGasRequest(EthEstimateGas(Solidity.Address(BigInteger.ONE), TEST_TX)),
+                "eth_estimateGas",
+                listOf(TEST_CALL_PARAMS),
+                rpcResult(),
+                EthRequest.Response.Failure<BigInteger>("Invalid estimate!")
+            ),
 
             // GasPrice
             TestCase(
@@ -225,6 +246,13 @@ class RpcRequestTest {
                 "eth_gasPrice",
                 emptyList(),
                 rpcResult("Invalid Number"),
+                EthRequest.Response.Failure<BigInteger>("Invalid gas price!")
+            ),
+            TestCase(
+                RpcGasPriceRequest(EthGasPrice()),
+                "eth_gasPrice",
+                emptyList(),
+                rpcResult(),
                 EthRequest.Response.Failure<BigInteger>("Invalid gas price!")
             ),
 
@@ -307,6 +335,13 @@ class RpcRequestTest {
                 rpcResult("Invalid Number"),
                 EthRequest.Response.Failure<BigInteger>("Invalid transaction count!")
             ),
+            TestCase(
+                RpcTransactionCountRequest(EthGetTransactionCount(Solidity.Address(BigInteger.TEN))),
+                "eth_getTransactionCount",
+                listOf(Solidity.Address(BigInteger.TEN).asEthereumAddressString(), "pending"),
+                rpcResult(),
+                EthRequest.Response.Failure<BigInteger>("Invalid transaction count!")
+            ),
 
             // SendRawTransaction
             TestCase(
@@ -323,6 +358,13 @@ class RpcRequestTest {
                 listOf("0x42cde4e8SomeSignedData"),
                 rpcResult(error = "Some Error"),
                 EthRequest.Response.Failure<String>("Some Error")
+            ),
+            TestCase(
+                RpcSendRawTransaction(EthSendRawTransaction("0x42cde4e8SomeSignedData")),
+                "eth_sendRawTransaction",
+                listOf("0x42cde4e8SomeSignedData"),
+                rpcResult(),
+                EthRequest.Response.Failure<String>("Missing result")
             )
         )
     }

--- a/ethereum-rpc/src/test/java/pm/gnosis/ethereum/rpc/models/RpcRequestTest.kt
+++ b/ethereum-rpc/src/test/java/pm/gnosis/ethereum/rpc/models/RpcRequestTest.kt
@@ -40,7 +40,7 @@ class RpcRequestTest {
 
     companion object {
 
-        private fun rpcResult(result: String = "0x", id: Int = 0, error: String? = null) =
+        private fun rpcResult(result: String? = null, id: Int = 0, error: String? = null) =
             JsonRpcResult(id, "2.0", error?.let { JsonRpcError(23, it) }, result)
 
         private val TEST_TX = Transaction(


### PR DESCRIPTION
Changes proposed in this pull request:
- Error responses might not have a result field, therefore it should be optional

@gnosis/mobile-devs
