### PR TITLE
Update dependencies. Using new Android Tools Gradle Plugin.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ android:
     - tools
 
     # The BuildTools version used by your project
-    - build-tools-27.0.3
+    - build-tools-28.0.3
 
     # The SDK version used to compile your project
-    - android-27
+    - android-28
 
     - extra-android-m2repository
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,12 +30,12 @@ subprojects {
     afterEvaluate { project ->
         if (project.hasProperty("android")) {
             android {
-                compileSdkVersion 27
-                buildToolsVersion "27.0.3"
+                compileSdkVersion 28
+                buildToolsVersion "28.0.3"
 
                 defaultConfig {
                     minSdkVersion 19
-                    targetSdkVersion 27
+                    targetSdkVersion 28
                 }
 
                 lintOptions {

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -1,8 +1,8 @@
 ext {
     versions = [
             // Plug-Ins
-            android_tools  : '3.1.4',
-            kotlin         : '1.2.61',
+            android_tools  : '3.2.0',
+            kotlin         : '1.2.71',
             jacoco         : '0.7.9',
 
             // Runtime dependencies


### PR DESCRIPTION
Changes proposed in this pull request:
- Kotlin (1.2.61 -> 1.2.71)
- Android Tools Gradle Plugin (3.1.4 -> 3.2.0)
- Android Build Tools (27.0.3 -> 28.0.3)

@gnosis/mobile-devs
