### PR TITLE
Made crypto and utils into java libraries instead of android

### DIFF
--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -2,7 +2,7 @@ ext {
     versions = [
             // Plug-Ins
             android_tools         : '3.3.0',
-            kotlin                : '1.3.71',
+            kotlin                : '1.3.72',
             jacoco                : '0.7.9',
 
             // Runtime dependencies

--- a/crypto/build.gradle
+++ b/crypto/build.gradle
@@ -1,6 +1,5 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply from: '../buildsystem/coverageReport.gradle'
+apply plugin: 'java-library'
+apply plugin: 'kotlin'
 
 dependencies {
     // We specify junit before anything else to make sure that this version is prioritized over the
@@ -19,6 +18,4 @@ dependencies {
 
     // Bivrost
     implementation "com.github.gnosis.bivrost-kotlin:bivrost-solidity-types:$versions.bivrost"
-
-    testImplementation project(":utils-testing")
 }

--- a/crypto/src/main/AndroidManifest.xml
+++ b/crypto/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="pm.gnosis.crypto" />

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -1,6 +1,5 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply from: '../buildsystem/coverageReport.gradle'
+apply plugin: 'java-library'
+apply plugin: 'kotlin'
 
 dependencies {
     // We specify junit before anything else to make sure that this version is prioritized over the
@@ -14,6 +13,4 @@ dependencies {
     implementation "com.github.gnosis.bivrost-kotlin:bivrost-solidity-types:$versions.bivrost"
 
     implementation "com.squareup.okio:okio:$versions.okio"
-
-    testImplementation project(':utils-testing')
 }

--- a/utils/src/main/AndroidManifest.xml
+++ b/utils/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="pm.gnosis.utils" />

--- a/utils/src/test/java/pm/gnosis/utils/Asserts.kt
+++ b/utils/src/test/java/pm/gnosis/utils/Asserts.kt
@@ -1,0 +1,15 @@
+package pm.gnosis.utils
+
+import org.junit.Assert
+
+object Asserts {
+    fun assertThrow(test: () -> Unit, message: String? = null, throwablePredicate: ((Throwable) -> Boolean)? = null) {
+        var success = false
+        try {
+            test()
+        } catch (t: Throwable) {
+            success = throwablePredicate?.invoke(t) ?: true
+        }
+        Assert.assertTrue(message ?: "Should have thrown", success)
+    }
+}

--- a/utils/src/test/java/pm/gnosis/utils/ExtensionsKtTest.kt
+++ b/utils/src/test/java/pm/gnosis/utils/ExtensionsKtTest.kt
@@ -3,7 +3,7 @@ package pm.gnosis.utils
 import okio.ByteString.Companion.decodeHex
 import org.junit.Assert.*
 import org.junit.Test
-import pm.gnosis.tests.utils.Asserts.assertThrow
+import pm.gnosis.utils.Asserts.assertThrow
 import java.math.BigInteger
 
 class ExtensionsKtTest {

--- a/utils/src/test/java/pm/gnosis/utils/NumberUtilsKtTest.kt
+++ b/utils/src/test/java/pm/gnosis/utils/NumberUtilsKtTest.kt
@@ -2,7 +2,7 @@ package pm.gnosis.utils
 
 import org.junit.Assert.*
 import org.junit.Test
-import pm.gnosis.tests.utils.Asserts.assertThrow
+import pm.gnosis.utils.Asserts.assertThrow
 import java.math.BigDecimal
 import java.math.BigInteger
 


### PR DESCRIPTION
Effort to find a feasible implementation to start work with #46 .

Changes proposed in this pull request:
- `crypto` and `utils` were turned into java libs
- codeCoverage had to be removed as it is expecting an android dependency (Offending line: `buildSystem/covergaReport.gradle@10` 
- `:utils-testing` is forcing the libraries into android because of the `TestPreferences`. Technically, it also forces the usage of `Rx` as it provides convenience methods for `Flowables`, `Schedulers`, etc.
- I added the only method used in `utils` from `utils-testing` which is `assertThrow`. I propose splitting `utils-testing` into 3, `utils-testing-commons`, `utils-testing-rx`, `utils-testing-android`.

@gnosis/mobile-devs
@rmeissner , This is probably not a high priority, but I started realising that the time/effort to cherry pick what I need for the `safe-sdk-kotlin` may be the same as the one required for migrating this. What's your opinion on this?